### PR TITLE
Build with GoReleaser

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -128,7 +128,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
         if: github.event_name != 'pull_request'
 
-      - name: Extract metadata (tags, labels) for Docker
+      - name: Docker metadata
         id: meta
         uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,8 +11,6 @@ on:
       - main
 
 env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
   # tailout environment variables
   TAILOUT_REGION: eu-west-3
   TAILOUT_NON_INTERACTIVE: "true"
@@ -80,6 +78,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Print tailout version
+        run: ./dist/tailout_linux_amd64_v1/tailout version
+
       - name: Cache Artifacts
         uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         with:
@@ -113,6 +114,12 @@ jobs:
           version: latest
           driver-opts: network=host
 
+      - name: Fetch Cached Artifacts
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+        with:
+          path: ${{ github.workspace }}/dist
+          key: tailout-${{ github.run_id }}-${{ github.run_number }}
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
@@ -126,7 +133,7 @@ jobs:
         uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
         with:
           images: |
-            name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},enable=${{ github.event_name != 'pull_request' }}
+            name=ghcr.io/${{ github.repository }},enable=${{ github.event_name != 'pull_request' }}
             name=localhost:5000/tailout/tailout-local
           tags: |
             type=edge
@@ -140,7 +147,7 @@ jobs:
           context: .
           push: true
           pull: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/arm/v5,linux/arm/v6,linux/arm/v7,linux/arm64,linux/amd64,linux/ppc64le,linux/s390x,linux/mips64le,linux/386,linux/riscv64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
@@ -173,7 +180,7 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
         with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-name: ghcr.io/${{ github.repository }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
         if: github.event_name != 'pull_request'

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,7 +6,7 @@ builds:
       - darwin
       - freebsd
       - linux
-      - solaris
+      # - solaris
       - windows
     goarch:
       - 386

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,6 +8,23 @@ builds:
       - linux
       - solaris
       - windows
+    goarch:
+      - 386
+      - amd64
+      - arm
+      - arm64
+      - mips64
+      - mips64le
+      - ppc64
+      - ppc64le
+      - riscv64
+      - s390x
+    goarm:
+      - 5
+      - 6
+      - 7
+    gomips:
+      - softfloat
     flags:
       - -trimpath
     binary: tailout

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,9 +3,13 @@ builds:
   - env:
       - CGO_ENABLED=0
     goos:
-      - linux
       - darwin
+      - freebsd
+      - linux
+      - solaris
       - windows
+    flags:
+      - -trimpath
     binary: tailout
 
 archives:
@@ -18,30 +22,5 @@ sboms:
     documents:
       - "${artifact}.spdx.json"
 
-checksum:
-  name_template: "checksums.txt"
-
-snapshot:
-  version_template: "{{ .Tag }}-next"
-
 changelog:
-  sort: asc
-  use: github
-  groups:
-    - title: Features
-      regexp: "^.*(feat:|feat\\/|feat(\\([^\\)]*\\)):).*"
-      order: 0
-    - title: "Bug fixes"
-      regexp: "^.*(fix:|fix\\/|fix(\\([^\\)]*\\)):).*"
-      order: 1
-    - title: Others
-      order: 999
-  filters:
-    exclude:
-      - "^docs"
-      - "^test"
-      - "^style"
-      - "^refactor"
-      - "^build"
-      - "^ci"
-      - "^chore(release)"
+  disable: true

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,6 +25,9 @@ builds:
       - 7
     gomips:
       - softfloat
+    ignore:
+      - goos: windows
+        goarch: arm
     flags:
       - -trimpath
     binary: tailout

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,37 @@
-FROM golang:1.25.1@sha256:bb979b278ffb8d31c8b07336fd187ef8fafc8766ebeaece524304483ea137e96 as fetch-stage
+# syntax=docker/dockerfile:1.17
+FROM golang:1.25.1 AS builder
+ARG TARGETARCH
 
-COPY go.mod go.sum /app/
-WORKDIR /app
+WORKDIR /go/src/github.com/lucacome/tailout
+
+COPY --link go.mod go.sum ./
 RUN go mod download
 
-FROM ghcr.io/a-h/templ:latest@sha256:70a8ea3b71b2bc4522fe3eb67f7dcaa0f2bb95b7f0bd087917bbb0410694ca7a AS generate-stage
-COPY --chown=65532:65532 . /app
-WORKDIR /app
-RUN ["templ", "generate"]
+COPY --link . .
 
-FROM cosmtrek/air@sha256:3def16c884b2b9409a4c7bb987cd76d656a12d0e0436fe8c583df93014e0356c as development
-COPY --from=generate-stage /ko-app/templ /bin/templ
-COPY --chown=65532:65532 . /app
-WORKDIR /app
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -trimpath -a -o tailout .
+
+
+FROM --platform=$BUILDPLATFORM alpine:3.22 AS certs
+
+
+FROM scratch AS base
+COPY --from=certs --link /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+USER 1001:1001
+ENTRYPOINT [ "/usr/bin/tailout" ]
+
+
+FROM base AS container
+COPY --from=builder /go/src/github.com/lucacome/tailout/tailout /usr/bin/
 EXPOSE 3000
-ENTRYPOINT ["air"]
 
-FROM golang:1.25.1@sha256:bb979b278ffb8d31c8b07336fd187ef8fafc8766ebeaece524304483ea137e96 AS build-stage
-COPY --from=generate-stage /app /app
-WORKDIR /app
-RUN CGO_ENABLED=0 GOOS=linux go build -buildvcs=false -o /app/app
 
-FROM gcr.io/distroless/base-debian12@sha256:fa15492938650e1a5b87e34d47dc7d99a2b4e8aefd81b931b3f3eb6bb4c1d2f6 AS deploy-stage
-WORKDIR /
-COPY --from=build-stage /app/app /app
-EXPOSE 3000
-USER nonroot:nonroot
-ENTRYPOINT ["/app"]
+FROM base AS goreleaser
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG TARGETPLATFORM
+
+LABEL org.lucacome.tailout.build.target="${TARGETPLATFORM}"
+LABEL org.lucacome.tailout.build.version="goreleaser"
+
+COPY --link dist/tailout_linux_${TARGETARCH}${TARGETVARIANT/v/_}*/tailout /usr/bin/tailout

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![CI](https://github.com/cterence/tailout/actions/workflows/ci.yaml/badge.svg)](https://github.com/cterence/tailout/actions/workflows/ci.yaml)
-[![Go Report Card](https://goreportcard.com/badge/github.com/cterence/tailout)](https://goreportcard.com/report/github.com/cterence/tailout)
+[![CI](https://github.com/lucacome/tailout/actions/workflows/ci.yaml/badge.svg)](https://github.com/lucacome/tailout/actions/workflows/ci.yaml)
+[![Go Report Card](https://goreportcard.com/badge/github.com/lucacome/tailout)](https://goreportcard.com/report/github.com/lucacome/tailout)
 
 # tailout
 
@@ -9,12 +9,12 @@
 
 ## Installation
 
-To install `tailout`, you can download the latest release from the [releases page](https://github.com/cterence/tailout/releases).
+To install `tailout`, you can download the latest release from the [releases page](https://github.com/lucacome/tailout/releases).
 
 You can also use the `go install` command:
 
 ```bash
-go install github.com/cterence/tailout@latest
+go install github.com/lucacome/tailout@latest
 ```
 
 ## Prerequisites

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"github.com/cterence/tailout/tailout"
+	"github.com/lucacome/tailout/tailout"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/cterence/tailout/tailout"
+	"github.com/lucacome/tailout/tailout"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/cterence/tailout/tailout"
+	"github.com/lucacome/tailout/tailout"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/disconnect.go
+++ b/cmd/disconnect.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/cterence/tailout/tailout"
+	"github.com/lucacome/tailout/tailout"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/cterence/tailout/tailout"
+	"github.com/lucacome/tailout/tailout"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/cterence/tailout/tailout"
+	"github.com/lucacome/tailout/tailout"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/cterence/tailout/tailout"
+	"github.com/lucacome/tailout/tailout"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/cterence/tailout/tailout"
+	"github.com/lucacome/tailout/tailout"
 	"github.com/spf13/cobra"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/cterence/tailout
+module github.com/lucacome/tailout
 
 go 1.25.1
 

--- a/internal/views/components/footer.templ
+++ b/internal/views/components/footer.templ
@@ -3,7 +3,7 @@ package components
 templ Footer() {
 	<footer class="fixed p-1 bottom-0 bg-gray-100 w-full border-t">
 		<div class="md:container md:mx-auto">
-			<a class="rounded-lg p-4 text-s text-blue-600 visited:text-purple-600 text-center" href="https://github.com/cterence/dead-drop" target="_blank">
+			<a class="rounded-lg p-4 text-s text-blue-600 visited:text-purple-600 text-center" href="https://github.com/lucacome/tailout" target="_blank">
 				github.com/lucacome/tailout
 			</a>
 		</div>

--- a/internal/views/components/footer.templ
+++ b/internal/views/components/footer.templ
@@ -4,7 +4,7 @@ templ Footer() {
 	<footer class="fixed p-1 bottom-0 bg-gray-100 w-full border-t">
 		<div class="md:container md:mx-auto">
 			<a class="rounded-lg p-4 text-s text-blue-600 visited:text-purple-600 text-center" href="https://github.com/lucacome/tailout" target="_blank">
-				github.com/lucacome/tailout
+				https://github.com/lucacome/tailout
 			</a>
 		</div>
 	</footer>

--- a/internal/views/components/footer.templ
+++ b/internal/views/components/footer.templ
@@ -4,7 +4,7 @@ templ Footer() {
 	<footer class="fixed p-1 bottom-0 bg-gray-100 w-full border-t">
 		<div class="md:container md:mx-auto">
 			<a class="rounded-lg p-4 text-s text-blue-600 visited:text-purple-600 text-center" href="https://github.com/cterence/dead-drop" target="_blank">
-				github.com/cterence/tailout
+				github.com/lucacome/tailout
 			</a>
 		</div>
 	</footer>

--- a/internal/views/components/footer_templ.go
+++ b/internal/views/components/footer_templ.go
@@ -29,7 +29,7 @@ func Footer() templ.Component {
 			templ_7745c5c3_Var1 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<footer class=\"fixed p-1 bottom-0 bg-gray-100 w-full border-t\"><div class=\"md:container md:mx-auto\"><a class=\"rounded-lg p-4 text-s text-blue-600 visited:text-purple-600 text-center\" href=\"https://github.com/cterence/dead-drop\" target=\"_blank\">github.com/cterence/tailout</a></div></footer>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<footer class=\"fixed p-1 bottom-0 bg-gray-100 w-full border-t\"><div class=\"md:container md:mx-auto\"><a class=\"rounded-lg p-4 text-s text-blue-600 visited:text-purple-600 text-center\" href=\"https://github.com/cterence/dead-drop\" target=\"_blank\">github.com/lucacome/tailout</a></div></footer>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/views/components/footer_templ.go
+++ b/internal/views/components/footer_templ.go
@@ -29,7 +29,7 @@ func Footer() templ.Component {
 			templ_7745c5c3_Var1 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<footer class=\"fixed p-1 bottom-0 bg-gray-100 w-full border-t\"><div class=\"md:container md:mx-auto\"><a class=\"rounded-lg p-4 text-s text-blue-600 visited:text-purple-600 text-center\" href=\"https://github.com/lucacome/tailout\" target=\"_blank\">github.com/lucacome/tailout</a></div></footer>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<footer class=\"fixed p-1 bottom-0 bg-gray-100 w-full border-t\"><div class=\"md:container md:mx-auto\"><a class=\"rounded-lg p-4 text-s text-blue-600 visited:text-purple-600 text-center\" href=\"https://github.com/lucacome/tailout\" target=\"_blank\">https://github.com/lucacome/tailout</a></div></footer>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/views/components/footer_templ.go
+++ b/internal/views/components/footer_templ.go
@@ -29,7 +29,7 @@ func Footer() templ.Component {
 			templ_7745c5c3_Var1 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<footer class=\"fixed p-1 bottom-0 bg-gray-100 w-full border-t\"><div class=\"md:container md:mx-auto\"><a class=\"rounded-lg p-4 text-s text-blue-600 visited:text-purple-600 text-center\" href=\"https://github.com/cterence/dead-drop\" target=\"_blank\">github.com/lucacome/tailout</a></div></footer>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<footer class=\"fixed p-1 bottom-0 bg-gray-100 w-full border-t\"><div class=\"md:container md:mx-auto\"><a class=\"rounded-lg p-4 text-s text-blue-600 visited:text-purple-600 text-center\" href=\"https://github.com/lucacome/tailout\" target=\"_blank\">github.com/lucacome/tailout</a></div></footer>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/views/index.templ
+++ b/internal/views/index.templ
@@ -1,6 +1,6 @@
 package views
 
-import "github.com/cterence/tailout/internal/views/components"
+import "github.com/lucacome/tailout/internal/views/components"
 
 templ Index() {
 	<!DOCTYPE html>

--- a/internal/views/index_templ.go
+++ b/internal/views/index_templ.go
@@ -8,7 +8,7 @@ package views
 import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
-import "github.com/cterence/tailout/internal/views/components"
+import "github.com/lucacome/tailout/internal/views/components"
 
 func Index() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {

--- a/main.go
+++ b/main.go
@@ -7,8 +7,8 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/cterence/tailout/cmd"
-	"github.com/cterence/tailout/tailout"
+	"github.com/lucacome/tailout/cmd"
+	"github.com/lucacome/tailout/tailout"
 )
 
 func main() {

--- a/tailout/app.go
+++ b/tailout/app.go
@@ -1,7 +1,7 @@
 package tailout
 
 import (
-	"github.com/cterence/tailout/tailout/config"
+	"github.com/lucacome/tailout/tailout/config"
 )
 
 type App struct {

--- a/tailout/connect.go
+++ b/tailout/connect.go
@@ -8,7 +8,7 @@ import (
 	"net/url"
 	"slices"
 
-	"github.com/cterence/tailout/internal"
+	"github.com/lucacome/tailout/internal"
 	"github.com/manifoldco/promptui"
 	"tailscale.com/client/tailscale"
 	tsapi "tailscale.com/client/tailscale/v2"

--- a/tailout/create.go
+++ b/tailout/create.go
@@ -17,7 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
-	"github.com/cterence/tailout/internal"
+	"github.com/lucacome/tailout/internal"
 	tsapi "tailscale.com/client/tailscale/v2"
 )
 

--- a/tailout/init.go
+++ b/tailout/init.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/cterence/tailout/internal"
+	"github.com/lucacome/tailout/internal"
 	tsapi "tailscale.com/client/tailscale/v2"
 )
 

--- a/tailout/status.go
+++ b/tailout/status.go
@@ -9,7 +9,7 @@ import (
 	"net/url"
 	"slices"
 
-	"github.com/cterence/tailout/internal"
+	"github.com/lucacome/tailout/internal"
 	"tailscale.com/client/tailscale"
 	tsapi "tailscale.com/client/tailscale/v2"
 )

--- a/tailout/stop.go
+++ b/tailout/stop.go
@@ -12,8 +12,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
-	"github.com/cterence/tailout/internal"
 	"github.com/ktr0731/go-fuzzyfinder"
+	"github.com/lucacome/tailout/internal"
 	tsapi "tailscale.com/client/tailscale/v2"
 )
 

--- a/tailout/ui.go
+++ b/tailout/ui.go
@@ -8,8 +8,8 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/cterence/tailout/internal"
-	"github.com/cterence/tailout/internal/views"
+	"github.com/lucacome/tailout/internal"
+	"github.com/lucacome/tailout/internal/views"
 	tsapi "tailscale.com/client/tailscale/v2"
 
 	"github.com/a-h/templ"

--- a/tailout/ui.go
+++ b/tailout/ui.go
@@ -80,7 +80,6 @@ func (app *App) UI(ctx context.Context, args []string) error {
 	// Serve assets files
 	http.Handle("/assets/", http.StripPrefix("/assets/", http.FileServer(http.Dir("internal/assets"))))
 
-	slog.Info("Server starting", "address", app.Config.UI.Address, "port", app.Config.UI.Port)
 	srv := &http.Server{
 		Addr:         app.Config.UI.Address + ":" + app.Config.UI.Port,
 		ReadTimeout:  5 * time.Second,
@@ -88,9 +87,29 @@ func (app *App) UI(ctx context.Context, args []string) error {
 		IdleTimeout:  120 * time.Second,
 	}
 
-	if err := srv.ListenAndServe(); err != nil {
-		slog.Error("Failed to start server", "error", err)
-		panic(err)
+	slog.Info("Server starting", "address", app.Config.UI.Address, "port", app.Config.UI.Port)
+
+	// Start server in a goroutine
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			slog.Error("Failed to start server", "error", err)
+		}
+	}()
+
+	// Wait for context cancellation
+	<-ctx.Done()
+	slog.Info("Shutting down server...")
+
+	// Create shutdown context with timeout
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Attempt graceful shutdown
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		slog.Error("Server shutdown failed", "error", err)
+		return fmt.Errorf("server shutdown failed: %w", err)
 	}
+
+	slog.Info("Server stopped")
 	return nil
 }


### PR DESCRIPTION
This pull request makes several important updates to rebrand the project from the old GitHub organization/user `cterence` to `lucacome`, improves the build and release pipeline, and enhances platform support. The main themes are repository migration, build system improvements, and codebase consistency.

**Repository migration and codebase consistency:**

* Updated all code references, imports, documentation, and links from `github.com/cterence/tailout` to `github.com/lucacome/tailout` across the codebase, including `go.mod`, source files, README, and UI components. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L1-R1) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R2) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L12-R17) [[4]](diffhunk://#diff-8e494a434a8037b6c0b888e25b2baae7618fe65e792d4a155dadd096e9350667L4-R4) [[5]](diffhunk://#diff-c7bebd1293e78133a946df5482607b08986ad9e4c74bb3989736d80fdd0a0755L6-R6) [[6]](diffhunk://#diff-e52f1f4fa0c533e3287cbe2ef0436582b5ca471a3fddcdf1f49fecd1ec0c7d13L6-R6) [[7]](diffhunk://#diff-ef26a2831129748fb263e0689e0b2d84413ba3b9bf076d4ebed1984b4cbfed2dL6-R6) [[8]](diffhunk://#diff-345cd3beb7d905a8bef99d83e99c62678bfd5101a26d30104ecc9320602072acL6-R6) [[9]](diffhunk://#diff-0e50d48603686e2554754c072b11971cdaedd8eaa64ef9e1e091860bea8eb117L6-R6) [[10]](diffhunk://#diff-9d672277c9ba9fd61b0aa798d540335c62e449af9299a0804340ba847ea9b5bdL6-R6) [[11]](diffhunk://#diff-2e94e569ac52c9ac5151ea0b3372d56c3775b7e8cfc1b9ed4d98f9a0e034e929L6-R6) [[12]](diffhunk://#diff-ab8da30555f69dbd448fadfa209303faf4e71fd125c69fbd532abeba0ee8cde1L7-R7) [[13]](diffhunk://#diff-91810d1e6cb00d14963e3d2bbec8cb54cc6d83bb110e27269516f38c976b7261L32-R32) [[14]](diffhunk://#diff-c33ee0a297de8c513fe1f38b9348881579dedda732fda2ed5469e844fc634349L3-R3) [[15]](diffhunk://#diff-c1b4b101e16d62ffb24026aeb06f48205417842d773a72a007b9c8d55e280046L11-R11) [[16]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L10-R11) [[17]](diffhunk://#diff-cca9751cd161cf26e1f3dba4a5b5f640e2b249a5b3888df6d7c2dc21670d6289L4-R4) [[18]](diffhunk://#diff-fe5df3e4c92528dc080f945faa1a4d41961f89ca9f3c1fba4e315de7f745dc46L11-R11)

**Build and release pipeline improvements:**

* Refactored the `Dockerfile` to streamline multi-stage builds, use `scratch` and `alpine` for minimal images, and support GoReleaser builds for multiple architectures. Removed unused development and templ stages.
* Updated `.goreleaser.yaml` to add support for additional OS targets (`freebsd`, `solaris`), set build flags (`-trimpath`), and disabled changelog generation for releases. [[1]](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826L6-R12) [[2]](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826L21-R26)

**CI/CD enhancements:**

* Improved `.github/workflows/ci.yaml` by removing unused environment variables, adding steps to print the `tailout` version, caching build artifacts, and fetching cached artifacts to optimize build times. [[1]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL14-L15) [[2]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR81-R83) [[3]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR117-R122)
* Updated Docker build and attestation steps to use the new repository name and expanded supported platforms for container images (including arm variants, ppc64le, s390x, mips64le, 386, riscv64). [[1]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL124-R136) [[2]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL143-R150) [[3]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL176-R183)

These changes ensure the project is correctly migrated, modernize the build and release process, and prepare the codebase for broader platform support and future development.