### PR TITLE
Remove hash in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# syntax=docker/dockerfile:1.18@sha256:dabfc0969b935b2080555ace70ee69a5261af8a8f1b4df97b9e7fbcf6722eddf
-FROM golang:1.25.1@sha256:bb979b278ffb8d31c8b07336fd187ef8fafc8766ebeaece524304483ea137e96 AS builder
+# syntax=docker/dockerfile:1.18
+FROM golang:1.25.1 AS builder
 ARG TARGETARCH
 
 WORKDIR /go/src/github.com/lucacome/tailout
@@ -12,7 +12,7 @@ COPY --link . .
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -trimpath -a -o tailout .
 
 
-FROM --platform=$BUILDPLATFORM alpine:3.22@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1 AS certs
+FROM --platform=$BUILDPLATFORM alpine:3.22 AS certs
 
 
 FROM scratch AS base


### PR DESCRIPTION
This pull request updates the `Dockerfile` to simplify image references by removing pinned digests from the base images. This makes the Dockerfile easier to maintain and less restrictive regarding specific image versions.

**Dockerfile simplification:**

* Removed the SHA256 digest from the `docker/dockerfile:1.18` syntax directive, now referencing only the version.
* Updated both the `golang:1.25.1` and `alpine:3.22` base images to remove their SHA256 digests, using only the version tags. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R2) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L15-R15)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container build configuration to use tag-based image references for base images and the Dockerfile syntax directive.
  * Build steps and multi-stage flow remain unchanged.
  * No changes to runtime behavior, features, or APIs; users should not see any differences.
  * Distribution artifacts and image names remain the same.
  * No action required for upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->