### PR TITLE
Add homebrew and sign artifacts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,13 +79,21 @@ jobs:
           collapse-after: 30
         if: github.event_name != 'pull_request'
 
+      - name: Download Syft
+        uses: anchore/sbom-action/download-syft@da167eac915b4e86f08b264dbdbc867b61be6f0c # v0.20.5
+        if: github.ref_type == 'tag'
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
+        if: github.ref_type == 'tag'
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           version: latest
           args: ${{ github.ref_type == 'tag' && 'release' || 'build --snapshot' }} --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
 
       - name: Print tailout version
         run: ./dist/tailout_linux_amd64_v1/tailout version

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: '32 13 * * 6'
+    - cron: "32 13 * * 6"
 
 jobs:
   analyze:
@@ -29,10 +29,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - language: actions
-          build-mode: none
-        - language: go
-          build-mode: autobuild
+          - language: actions
+            build-mode: none
+          - language: go
+            build-mode: autobuild
         # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
@@ -42,29 +42,29 @@ jobs:
         # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-    - name: Setup Golang Environment
-      uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
-      with:
-        go-version: stable
-      if: matrix.language == 'go'
+      - name: Setup Golang Environment
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+        with:
+          go-version: stable
+        if: matrix.language == 'go'
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@192325c86100d080feab897ff886c34abd4c83a3 # v3.30.3
-      with:
-        languages: ${{ matrix.language }}
-        build-mode: ${{ matrix.build-mode }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@192325c86100d080feab897ff886c34abd4c83a3 # v3.30.3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
 
-        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
+          # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+          # queries: security-extended,security-and-quality
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@192325c86100d080feab897ff886c34abd4c83a3 # v3.30.3
-      with:
-        category: "/language:${{matrix.language}}"
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@192325c86100d080feab897ff886c34abd4c83a3 # v3.30.3
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -69,7 +69,7 @@ homebrew_casks:
       name: homebrew-tap
     description: "Spawn an exit node for your tailnet anywhere with Tailout"
     homepage: "https://github.com/lucacome/tailout"
-    license: "Apache-2.0, MIT"
+    license: "Apache-2.0 AND MIT"
     hooks:
       post:
         install: |

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -39,8 +39,40 @@ archives:
 
 sboms:
   - artifacts: archive
+    args:
+      - scan
+      - "--enrich=all"
+      - "$artifact"
+      - "--output"
+      - "spdx-json=$document"
     documents:
       - "${artifact}.spdx.json"
 
 changelog:
   disable: true
+
+signs:
+  - cmd: cosign
+    artifacts: checksum
+    output: true
+    certificate: "${artifact}.pem"
+    args:
+      - sign-blob
+      - "--output-signature=${signature}"
+      - "--output-certificate=${certificate}"
+      - "${artifact}"
+      - "--yes"
+
+homebrew_casks:
+  - repository:
+      owner: lucacome
+      name: homebrew-tap
+    description: "Spawn an exit node for your tailnet anywhere with Tailout"
+    homepage: "https://github.com/lucacome/tailout"
+    license: "Apache-2.0, MIT"
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/tailout"]
+          end

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,3 +47,6 @@ repos:
     rev: v2.4.0
     hooks:
       - id: golangci-lint-full
+
+ci:
+  autoupdate_schedule: quarterly # Renovate is used for more frequent updates and there's no way to disable autoupdate


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Release artifacts are now cryptographically signed; signatures and certificates are published.
  - SBOMs (SPDX JSON) are generated for each release.
  - Homebrew cask available for macOS (lucacome/homebrew-tap) enabling easy install; post-install removes quarantine attribute.

- Chores
  - CI updated for tag builds to enable signing/SBOM tooling and use a new release token.
  - CodeQL workflow formatting cleanup with no behavioral changes.
  - Pre-commit autoupdate cadence set to quarterly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->